### PR TITLE
Annotate all terms

### DIFF
--- a/endive-lsp-server/bin/complete.ml
+++ b/endive-lsp-server/bin/complete.ml
@@ -1,0 +1,70 @@
+open Endive.Term
+open Endive.Span
+open Endive.Stmt
+
+let rec find_map_term f env stmts =
+  match stmts with
+  | [] -> None
+  | stmt :: rest -> (
+      match stmt with
+      | Lemma ((x, t), stmts) -> (
+          match f t env with
+          | Some res -> Some res
+          | None -> (
+              match find_map_term f env stmts with
+              | Some res -> Some res
+              | None -> find_map_term f ((x.el, t.el) :: env) rest))
+      | Let (x, t) -> (
+          match f t env with
+          | Some res -> Some res
+          | None -> find_map_term f ((x.el, t.el) :: env) rest)
+      | Exact t -> (
+          match f t env with
+          | Some res -> Some res
+          | None -> find_map_term f env rest))
+
+let inside_term (pos : Lsp.Types.Position.t) (t : term annotated) =
+  match t.span with
+  | Some s ->
+      pos.line >= s.start.line && pos.line <= s.end_.line
+      && pos.character >= s.start.column
+      && pos.character <= s.end_.column
+  | None -> false
+
+let complete env x =
+  let rec aux env acc =
+    match env with
+    | [] -> acc
+    | (y, t) :: rest ->
+        if String.starts_with ~prefix:x y then
+          let detail = string_of_term t in
+          let completion =
+            Lsp.Types.CompletionItem.create ?detail:(Some detail) ~label:y ()
+          in
+          aux rest (completion :: acc)
+        else aux rest acc
+  in
+  aux env []
+
+let complete_in_term (pos : Lsp.Types.Position.t) (t : term annotated)
+    (env : (string * term) list) =
+  let rec aux t env =
+    if inside_term pos t then
+      match t.el with
+      | Var x -> Some (complete env x)
+      | Lam ((x, t1), t2) | Pi ((x, t1), t2) -> (
+          match aux t1 env with
+          | Some res -> Some res
+          | None -> aux t2 ((x.el, t1.el) :: env))
+      | App (t1, t2) -> (
+          match aux t1 env with Some res -> Some res | None -> aux t2 env)
+      | Univ _ -> None
+    else None
+  in
+  aux t env
+
+let compute_completions (pos : Lsp.Types.Position.t) (stmts : stmt list) =
+  let items =
+    Option.value ~default:[] (find_map_term (complete_in_term pos) [] stmts)
+  in
+  Lsp.Types.CompletionList.create ~isIncomplete:false ~items ()

--- a/endive-lsp-server/bin/main_loop.ml
+++ b/endive-lsp-server/bin/main_loop.ml
@@ -50,7 +50,8 @@ let parse_and_publish_diags doc =
 
 let main_loop () =
   let docs = Hashtbl.create 2 in
-  while true do
+  let continue = ref true in
+  while !continue do
     match Std_io.read () () with
     | Some (Jsonrpc.Packet.Request req) -> (
         match Lsp.Client_request.of_jsonrpc req with
@@ -109,5 +110,5 @@ let main_loop () =
             Hashtbl.replace docs params.textDocument.uri doc;
             parse_and_publish_diags doc
         | _ -> ())
-    | _ -> ()
+    | _ -> continue := false
   done

--- a/endive/src/span.ml
+++ b/endive/src/span.ml
@@ -1,3 +1,6 @@
 type pos = { line : int; column : int }
 type span = { start : pos; end_ : pos }
 type 'a annotated = { el : 'a; span : span option }
+
+let fresh el = { el; span = None }
+let map f { el; span } = { el = f el; span }

--- a/endive/src/stmt.ml
+++ b/endive/src/stmt.ml
@@ -1,8 +1,6 @@
 open Span
 open Term
 
-type annotated_binding = string * term annotated
-
 type stmt =
   | Lemma of annotated_binding * stmt list
   | Let of annotated_binding

--- a/endive/src/term.ml
+++ b/endive/src/term.ml
@@ -1,23 +1,26 @@
+open Span
+
 type term =
   | Var of string
-  | Lam of binding * term
-  | App of term * term
-  | Pi of binding * term
-  | Univ of int
+  | Lam of annotated_binding * term annotated
+  | App of term annotated * term annotated
+  | Pi of annotated_binding * term annotated
+  | Univ of int annotated
 
-and binding = string * term
+and annotated_binding = string annotated * term annotated
 
-type env = binding list
-
-let term_fun t1 t2 = Pi (("_", t1), t2)
-let term_not t = term_fun t (Var "False")
+let term_fun t1 t2 = Pi ((fresh "_", t1), t2)
+let term_not t = term_fun t (fresh (Var "False"))
 
 let rec subst t x u =
   match t with
   | Var y when y = x -> u
-  | Lam ((y, t1), t2) when y != x -> Lam ((y, t1), subst t2 x u)
-  | App (t1, t2) -> App (subst t1 x u, subst t2 x u)
-  | Pi ((y, t1), t2) when y != x -> Pi ((y, t1), subst t2 x u)
+  | Lam ((y, t1), t2) when y.el != x ->
+      Lam ((y, t1), map (fun t2 -> subst t2 x u) t2)
+  | App (t1, t2) ->
+      App (map (fun t1 -> subst t1 x u) t1, map (fun t2 -> subst t2 x u) t2)
+  | Pi ((y, t1), t2) when y.el != x ->
+      Pi ((y, t1), map (fun t2 -> subst t2 x u) t2)
   | _ -> t
 
 let rec alpha_eq t u map =
@@ -26,54 +29,58 @@ let rec alpha_eq t u map =
       let x = Option.value ~default:x (List.assoc_opt x map) in
       x = x'
   | Lam ((x, t1), t2), Lam ((x', t1'), t2') ->
-      alpha_eq t1 t1' map && alpha_eq t2 t2' ((x, x') :: map)
-  | App (t, u), App (v, w) -> alpha_eq t v map && alpha_eq u w map
+      alpha_eq t1.el t1'.el map && alpha_eq t2.el t2'.el ((x.el, x'.el) :: map)
+  | App (t, u), App (v, w) -> alpha_eq t.el v.el map && alpha_eq u.el w.el map
   | Pi ((x, t1), t2), Pi ((x', t1'), t2') ->
-      alpha_eq t1 t1' map && alpha_eq t2 t2' ((x, x') :: map)
+      alpha_eq t1.el t1'.el map && alpha_eq t2.el t2'.el ((x.el, x'.el) :: map)
   | Univ n, Univ m -> n = m
   | _ -> false
 
 let rec sub_ty t u map =
   match (t, u) with
   | Pi ((x, t1), t2), Pi ((x', t1'), t2') ->
-      sub_ty t1' t1 map && sub_ty t2 t2' ((x, x') :: map)
+      sub_ty t1'.el t1.el map && sub_ty t2.el t2'.el ((x.el, x'.el) :: map)
   | Univ n, Univ m -> n <= m
   | _ -> alpha_eq t u map
 
 let rec normal_form t =
   match t with
-  | Lam ((x, t1), t2) -> Lam ((x, normal_form t1), normal_form t2)
+  | Lam ((x, t1), t2) -> Lam ((x, map normal_form t1), map normal_form t2)
   | App (t1, t2) -> (
-      let t1' = normal_form t1 in
-      let t2' = normal_form t2 in
-      match t1' with
-      | Lam ((x, _t3), t4) -> normal_form (subst t4 x t2')
+      let t1' = map normal_form t1 in
+      let t2' = map normal_form t2 in
+      match t1'.el with
+      | Lam ((x, _), t3) -> normal_form (subst t3.el x.el t2'.el)
       | _ -> App (t1', t2'))
-  | Pi ((x, t1), t2) -> Pi ((x, normal_form t1), normal_form t2)
+  | Pi ((x, t1), t2) -> Pi ((x, map normal_form t1), map normal_form t2)
   | _ -> t
 
 let rec ty t env =
   match t with
   | Var x -> List.assoc_opt x env
   | Lam ((x, t1), t2) -> (
-      match ty t2 ((x, t1) :: env) with
-      | Some t3 -> Some (Pi ((x, t1), t3))
+      match ty t2.el ((x.el, t1) :: env) with
+      | Some t3 -> Some (fresh (Pi ((x, t1), t3)))
       | None -> None)
   | App (t1, t2) -> (
-      match (ty t1 env, ty t2 env) with
-      | Some (Pi ((x, t3), t4)), Some t5 ->
-          let t3' = normal_form t3 in
-          let t5' = normal_form t5 in
-          if sub_ty t5' t3' [] then Some (normal_form (subst t4 x t5'))
+      match (ty t1.el env, ty t2.el env) with
+      | Some { el = Pi ((x, t3), t4); span = _ }, Some t5 ->
+          let t3' = normal_form t3.el in
+          let t5' = normal_form t5.el in
+          if sub_ty t5' t3' [] then
+            Some (fresh (normal_form (subst t4.el x.el t5')))
           else None
       | _ -> None)
   | Pi ((x, t1), t2) -> (
-      match (univ_level t1 env, univ_level t2 ((x, t1) :: env)) with
-      | Some t3, Some t4 -> Some (Univ (max t3 t4))
+      match (univ_level t1.el env, univ_level t2.el ((x.el, t1) :: env)) with
+      | Some t3, Some t4 ->
+          if t3.el >= t4.el then Some (fresh (Univ t3))
+          else Some (fresh (Univ t4))
       | _ -> None)
-  | Univ n -> Some (Univ (n + 1))
+  | Univ n -> Some (fresh (Univ (fresh (n.el + 1))))
 
-and univ_level t env = match ty t env with Some (Univ n) -> Some n | _ -> None
+and univ_level t env =
+  match ty t env with Some { el = Univ n; span = _ } -> Some n | _ -> None
 
 let string_of_term t =
   let rec aux t ~paren_around_app ~paren_around_arrow ~paren_around_lam =
@@ -82,52 +89,52 @@ let string_of_term t =
     | Lam ((x, t1), t2) ->
         let l, r = if paren_around_lam then ("(", ")") else ("", "") in
         let s1 =
-          aux t1 ~paren_around_app:false ~paren_around_arrow:false
+          aux t1.el ~paren_around_app:false ~paren_around_arrow:false
             ~paren_around_lam:false
         in
         let s2 =
-          aux t2 ~paren_around_app:false ~paren_around_arrow:false
+          aux t2.el ~paren_around_app:false ~paren_around_arrow:false
             ~paren_around_lam:true
         in
-        Printf.sprintf "%sfun %s : %s => %s%s" l x s1 s2 r
+        Printf.sprintf "%sfun %s : %s => %s%s" l x.el s1 s2 r
     | App (t1, t2) ->
         let l, r = if paren_around_app then ("(", ")") else ("", "") in
         let s1 =
-          aux t1 ~paren_around_app:false ~paren_around_arrow:true
+          aux t1.el ~paren_around_app:false ~paren_around_arrow:true
             ~paren_around_lam:true
         in
         let s2 =
-          aux t2 ~paren_around_app:true ~paren_around_arrow:true
+          aux t2.el ~paren_around_app:true ~paren_around_arrow:true
             ~paren_around_lam:false
         in
         Printf.sprintf "%s%s %s%s" l s1 s2 r
-    | Pi ((_x, t1), Var "False") ->
+    | Pi ((_x, t1), { el = Var "False"; span = _ }) ->
         "~"
-        ^ aux t1 ~paren_around_app:true ~paren_around_arrow:true
+        ^ aux t1.el ~paren_around_app:true ~paren_around_arrow:true
             ~paren_around_lam:true
-    | Pi (("_", t1), t2) ->
+    | Pi (({ el = "_"; span = _ }, t1), t2) ->
         let l, r = if paren_around_arrow then ("(", ")") else ("", "") in
         let s1 =
-          aux t1 ~paren_around_app:false ~paren_around_arrow:true
+          aux t1.el ~paren_around_app:false ~paren_around_arrow:true
             ~paren_around_lam:true
         in
         let s2 =
-          aux t2 ~paren_around_app:false ~paren_around_arrow:false
+          aux t2.el ~paren_around_app:false ~paren_around_arrow:false
             ~paren_around_lam:true
         in
         Printf.sprintf "%s%s -> %s%s" l s1 s2 r
     | Pi ((x, t1), t2) ->
         let l, r = if paren_around_lam then ("(", ")") else ("", "") in
         let s1 =
-          aux t1 ~paren_around_app:false ~paren_around_arrow:false
+          aux t1.el ~paren_around_app:false ~paren_around_arrow:false
             ~paren_around_lam:false
         in
         let s2 =
-          aux t2 ~paren_around_app:false ~paren_around_arrow:false
+          aux t2.el ~paren_around_app:false ~paren_around_arrow:false
             ~paren_around_lam:false
         in
-        Printf.sprintf "%sforall %s : %s, %s%s" l x s1 s2 r
-    | Univ n -> Printf.sprintf "Type@{%d}" n
+        Printf.sprintf "%sforall %s : %s, %s%s" l x.el s1 s2 r
+    | Univ n -> Printf.sprintf "Type@{%d}" n.el
   in
   aux t ~paren_around_app:false ~paren_around_arrow:false
     ~paren_around_lam:false

--- a/endive/src/validate.ml
+++ b/endive/src/validate.ml
@@ -17,10 +17,7 @@ let validate stmts =
             let errs = aux stmts env proven errs (Some t') in
             let env = (x.el, t') :: env in
             aux rest env proven errs goal
-        | Error span ->
-            aux rest env proven
-              ({ el = "The lemma goal is invalid."; span } :: errs)
-              goal)
+        | Error e -> aux rest env proven (e :: errs) goal)
     | Stmt.Let (x, t1) :: rest -> (
         match Term.ty t1 env with
         | Ok _ -> (
@@ -39,14 +36,11 @@ let validate stmts =
                   };
                 ]
             | None -> let_ rest env proven errs None x.el t1')
-        | Error span -> [ { el = "Invalid type in let."; span } ])
+        | Error e -> [ e ])
     | Stmt.Exact t :: rest -> (
         match Term.ty t env with
         | Ok t1 -> aux rest env (t1.el :: proven) errs goal
-        | Error span ->
-            aux rest env proven
-              ({ el = "Invalid term in exact."; span } :: errs)
-              goal)
+        | Error e -> aux rest env proven (e :: errs) goal)
   and let_ rest env proven errs goal x t =
     let env = (x, t) :: env in
     aux rest env proven errs goal

--- a/endive/test/parser_tests.ml
+++ b/endive/test/parser_tests.ml
@@ -11,9 +11,27 @@ let%test "parse let" =
   = Some
       [
         Let
-          ( "x",
+          ( {
+              el = "x";
+              span =
+                Some
+                  {
+                    start = { line = 0; column = 4 };
+                    end_ = { line = 0; column = 5 };
+                  };
+            },
             {
-              el = Univ 0;
+              el =
+                Univ
+                  {
+                    el = 0;
+                    span =
+                      Some
+                        {
+                          start = { line = 0; column = 14 };
+                          end_ = { line = 0; column = 15 };
+                        };
+                  };
               span =
                 Some
                   {
@@ -29,7 +47,26 @@ let%test "parse exact" =
       [
         Exact
           {
-            el = App (Var "x", Var "y");
+            el =
+              App
+                ( {
+                    el = Var "x";
+                    span =
+                      Some
+                        {
+                          start = { line = 0; column = 6 };
+                          end_ = { line = 0; column = 7 };
+                        };
+                  },
+                  {
+                    el = Var "y";
+                    span =
+                      Some
+                        {
+                          start = { line = 0; column = 8 };
+                          end_ = { line = 0; column = 9 };
+                        };
+                  } );
             span =
               Some
                 {
@@ -44,7 +81,15 @@ let%test "parse lemma" =
   = Some
       [
         Lemma
-          ( ( "lemma",
+          ( ( {
+                el = "lemma";
+                span =
+                  Some
+                    {
+                      start = { line = 0; column = 6 };
+                      end_ = { line = 0; column = 11 };
+                    };
+              },
               {
                 el = Var "P";
                 span =

--- a/endive/test/term_tests.ml
+++ b/endive/test/term_tests.ml
@@ -41,17 +41,17 @@ let%test "normal form: beta reduction under application" =
   normal_form t = t'
 
 let%test "type checking" =
-  let t1 = Lam ((fresh "x", fresh (Var "X")), fresh (Var "x")) in
+  let t1 = fresh (Lam ((fresh "x", fresh (Var "X")), fresh (Var "x"))) in
   let t2 = term_fun (fresh (Var "X")) (fresh (Var "X")) in
-  match ty t1 [] with Some t2' -> alpha_eq t2'.el t2 [] | None -> false
+  match ty t1 [] with Ok t2' -> alpha_eq t2'.el t2 [] | Error _ -> false
 
 let%test "type universe" =
-  let t1 = term_fun (fresh (Var "X")) (fresh (Var "Y")) in
-  let t2 = term_fun (fresh (Univ (fresh 0))) (fresh (Univ (fresh 1))) in
-  let t3 = Univ (fresh 1) in
-  let t4 = Lam ((fresh "X", fresh (Univ (fresh 0))), fresh (Var "X")) in
+  let t1 = fresh (term_fun (fresh (Var "X")) (fresh (Var "Y"))) in
+  let t2 = fresh (term_fun (fresh (Univ (fresh 0))) (fresh (Univ (fresh 1)))) in
+  let t3 = fresh (Univ (fresh 1)) in
+  let t4 = fresh (Lam ((fresh "X", fresh (Univ (fresh 0))), fresh (Var "X"))) in
   univ_level t1 [ ("X", fresh (Univ (fresh 0))); ("Y", fresh (Univ (fresh 0))) ]
-  = Some (fresh 0)
-  && univ_level t2 [] = Some (fresh 2)
-  && univ_level t3 [] = Some (fresh 2)
-  && univ_level t4 [] = None
+  = Ok (fresh 0)
+  && univ_level t2 [] = Ok (fresh 2)
+  && univ_level t3 [] = Ok (fresh 2)
+  && univ_level t4 [] = Error None

--- a/endive/test/term_tests.ml
+++ b/endive/test/term_tests.ml
@@ -1,39 +1,57 @@
 open Endive.Term
+open Endive.Span
 
 let%test "stringify term" =
   let t =
     Pi
-      ( ("P", Univ 1),
-        term_fun (term_fun (Var "P") (term_not (Var "P"))) (Var "P") )
+      ( (fresh "P", fresh (Univ (fresh 1))),
+        fresh
+          (term_fun
+             (fresh
+                (term_fun (fresh (Var "P"))
+                   (fresh (term_not (fresh (Var "P"))))))
+             (fresh (Var "P"))) )
   in
   string_of_term t = "forall P : Type@{1}, (P -> ~P) -> P"
 
 let%test "alpha equivalence" =
-  let t = Pi (("P", Univ 1), Var "P") in
-  let t' = Pi (("Q", Univ 1), Var "Q") in
+  let t = Pi ((fresh "P", fresh (Univ (fresh 1))), fresh (Var "P")) in
+  let t' = Pi ((fresh "Q", fresh (Univ (fresh 1))), fresh (Var "Q")) in
   alpha_eq t t' []
 
 let%test "normal form: beta reduction" =
-  let t = App (Lam (("x", Var "X"), Var "x"), Var "y") in
+  let t =
+    App
+      ( fresh (Lam ((fresh "x", fresh (Var "X")), fresh (Var "x"))),
+        fresh (Var "y") )
+  in
   let t' = Var "y" in
   normal_form t = t'
 
 let%test "normal form: beta reduction under application" =
-  let t = App (Var "f", App (Lam (("x", Var "X"), Var "x"), Var "y")) in
-  let t' = App (Var "f", Var "y") in
+  let t =
+    App
+      ( fresh (Var "f"),
+        fresh
+          (App
+             ( fresh (Lam ((fresh "x", fresh (Var "X")), fresh (Var "x"))),
+               fresh (Var "y") )) )
+  in
+  let t' = App (fresh (Var "f"), fresh (Var "y")) in
   normal_form t = t'
 
 let%test "type checking" =
-  let t1 = Lam (("x", Var "X"), Var "x") in
-  let t2 = term_fun (Var "X") (Var "X") in
-  match ty t1 [] with Some t2' -> alpha_eq t2' t2 [] | None -> false
+  let t1 = Lam ((fresh "x", fresh (Var "X")), fresh (Var "x")) in
+  let t2 = term_fun (fresh (Var "X")) (fresh (Var "X")) in
+  match ty t1 [] with Some t2' -> alpha_eq t2'.el t2 [] | None -> false
 
 let%test "type universe" =
-  let t1 = term_fun (Var "X") (Var "Y") in
-  let t2 = term_fun (Univ 0) (Univ 1) in
-  let t3 = Univ 1 in
-  let t4 = Lam (("X", Univ 0), Var "X") in
-  univ_level t1 [ ("X", Univ 0); ("Y", Univ 0) ] = Some 0
-  && univ_level t2 [] = Some 2
-  && univ_level t3 [] = Some 2
+  let t1 = term_fun (fresh (Var "X")) (fresh (Var "Y")) in
+  let t2 = term_fun (fresh (Univ (fresh 0))) (fresh (Univ (fresh 1))) in
+  let t3 = Univ (fresh 1) in
+  let t4 = Lam ((fresh "X", fresh (Univ (fresh 0))), fresh (Var "X")) in
+  univ_level t1 [ ("X", fresh (Univ (fresh 0))); ("Y", fresh (Univ (fresh 0))) ]
+  = Some (fresh 0)
+  && univ_level t2 [] = Some (fresh 2)
+  && univ_level t3 [] = Some (fresh 2)
   && univ_level t4 [] = None

--- a/endive/test/term_tests.ml
+++ b/endive/test/term_tests.ml
@@ -54,4 +54,5 @@ let%test "type universe" =
   = Ok (fresh 0)
   && univ_level t2 [] = Ok (fresh 2)
   && univ_level t3 [] = Ok (fresh 2)
-  && univ_level t4 [] = Error None
+  && univ_level t4 []
+     = Error { el = "This term is expected to be type."; span = None }


### PR DESCRIPTION
Add span information to all terms so that we can display more precise errors:
![More precise errors](https://github.com/ApollineRodary/Endive/assets/56923875/de7d0153-1903-4de0-93df-c039807cfe86)

And get very bare bones autocompletion: 
![Bare bones autocompletion](https://github.com/ApollineRodary/Endive/assets/56923875/3dcf9804-71a2-4a35-a649-2bf998b60e52)

Unfortunately, it only works when the whole file parses correctly ;(
