### PR TITLE
Prepare to move inductive types to a global context

### DIFF
--- a/crates/endive-engine/src/lib.rs
+++ b/crates/endive-engine/src/lib.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use endive_kernel::{Binding, Ix};
+use endive_kernel::{Binding, GlobalEnv, Ix};
 use endive_lambda::Tm;
 
 pub struct Engine {
@@ -28,7 +28,7 @@ impl Engine {
     pub fn prove(&mut self, name: String, tm: &Tm, ty: &Tm) -> Result<(), Error> {
         let ty = self.normalize_internal(ty)?;
         let tm = self.normalize_internal(tm)?;
-        if ty != tm.ty().unwrap() {
+        if ty != tm.ty(&GlobalEnv::new()).unwrap() {
             return Err(Error::InvalidTy);
         }
         self.defs.insert(name, tm);
@@ -42,7 +42,7 @@ impl Engine {
 
     fn normalize_internal(&self, tm: &Tm) -> Result<endive_kernel::Tm, Error> {
         let tm = self.translate_tm(tm, &mut vec![])?;
-        if tm.ty().is_err() {
+        if tm.ty(&GlobalEnv::new()).is_err() {
             return Err(Error::InvalidTy);
         }
         Ok(tm

--- a/crates/endive-kernel/src/closure.rs
+++ b/crates/endive-kernel/src/closure.rs
@@ -1,0 +1,27 @@
+use std::rc::Rc;
+
+use crate::{Binding, Ctx, Error, Lvl, Tm, Val};
+
+/// Lambda abstraction or dependent product type with a local context.
+#[derive(Clone, Debug)]
+pub(crate) struct Closure {
+    pub ty: Val,
+    pub body: Tm,
+    pub c: Rc<Ctx>,
+}
+
+impl Closure {
+    /// Applies the closure to a value.
+    pub(crate) fn apply(&self, val: Val) -> Result<Val, Error> {
+        self.body.eval(&self.c.push(val))
+    }
+
+    /// Reifies the closure into an abstraction in normal form. Variables are reified into de
+    /// Bruijn indices assuming current level `l`.
+    pub(crate) fn reify(&self, l: Lvl) -> Result<Binding, Error> {
+        Ok(Binding {
+            bound_ty: self.ty.reify(l)?,
+            body: self.apply(Val::Var(l))?.reify(Lvl(l.0 + 1))?,
+        })
+    }
+}

--- a/crates/endive-kernel/src/closure.rs
+++ b/crates/endive-kernel/src/closure.rs
@@ -2,18 +2,39 @@ use std::rc::Rc;
 
 use crate::{Binding, Ctx, Error, Lvl, Tm, Val};
 
-/// Lambda abstraction or dependent product type with a local context.
+/// A lambda term accompanied by a local context.
 #[derive(Clone, Debug)]
 pub(crate) struct Closure {
-    pub ty: Val,
-    pub body: Tm,
-    pub c: Rc<Ctx>,
+    pub(crate) body: Tm,
+    pub(crate) c: Rc<Ctx>,
 }
 
 impl Closure {
+    /// Creates a new closure.
+    pub(crate) fn new(body: Tm, c: Rc<Ctx>) -> Self {
+        Closure { body, c }
+    }
+}
+
+/// Lambda abstraction or dependent product type with a local context.
+#[derive(Clone, Debug)]
+pub(crate) struct BindingClosure {
+    pub ty: Val,
+    pub closure: Closure,
+}
+
+impl BindingClosure {
+    /// Creates a new binding closure.
+    pub(crate) fn new(ty: Val, body: Tm, c: Rc<Ctx>) -> Self {
+        BindingClosure {
+            ty,
+            closure: Closure::new(body, c),
+        }
+    }
+
     /// Applies the closure to a value.
     pub(crate) fn apply(&self, val: Val) -> Result<Val, Error> {
-        self.body.eval(&self.c.push(val))
+        self.closure.body.eval(&self.closure.c.push(val))
     }
 
     /// Reifies the closure into an abstraction in normal form. Variables are reified into de

--- a/crates/endive-kernel/src/global_env.rs
+++ b/crates/endive-kernel/src/global_env.rs
@@ -1,0 +1,21 @@
+use crate::InductiveTypeFamily;
+
+/// Global environment, which stores inducive type families.
+pub struct GlobalEnv {
+    /// Inductive type families.
+    inductives: Vec<InductiveTypeFamily>,
+}
+
+impl GlobalEnv {
+    /// Creates a new global environment.
+    pub fn new() -> Self {
+        GlobalEnv {
+            inductives: Vec::new(),
+        }
+    }
+
+    /// Adds an inductive type family to the global environment.
+    pub fn add_inductive(&mut self, family: InductiveTypeFamily) {
+        self.inductives.push(family);
+    }
+}

--- a/crates/endive-kernel/src/induction.rs
+++ b/crates/endive-kernel/src/induction.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::{univ_lvl, Binding, Closure, Ctx, Error, Lvl, Tm, TyCtx, Val};
+use crate::{univ_lvl, Binding, BindingClosure, Ctx, Error, Lvl, Tm, TyCtx, Val};
 
 /// A sequence of types. For each type, an argument of that type is bound in every subsequent type.
 pub struct Telescope(pub Vec<Tm>);
@@ -49,11 +49,11 @@ impl Telescope {
                     body: acc,
                 }))
             });
-            Ok(Val::Pi(Box::new(Closure {
-                ty: self.0[0].eval(c)?,
-                body: tail,
-                c: c.clone(),
-            })))
+            Ok(Val::Pi(Box::new(BindingClosure::new(
+                self.0[0].eval(c)?,
+                tail,
+                c.clone(),
+            ))))
         }
     }
 

--- a/crates/endive-kernel/src/induction.rs
+++ b/crates/endive-kernel/src/induction.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::{univ_lvl, Binding, BindingClosure, Ctx, Error, Lvl, Tm, TyCtx, Val};
+use crate::{univ_lvl, Binding, BindingClosure, Ctx, Error, GlobalEnv, Lvl, Tm, TyCtx, Val};
 
 /// A sequence of types. For each type, an argument of that type is bound in every subsequent type.
 pub struct Telescope(pub Vec<Tm>);
@@ -8,9 +8,14 @@ pub struct Telescope(pub Vec<Tm>);
 impl Telescope {
     /// Adds the parameters to the context and their types to the type context, returning the
     /// resulting context and type context.
-    fn add_to_ctx(&self, mut c: Rc<Ctx>, mut tc: Rc<TyCtx>) -> Result<(Rc<Ctx>, Rc<TyCtx>), Error> {
+    fn add_to_ctx(
+        &self,
+        e: &GlobalEnv,
+        mut c: Rc<Ctx>,
+        mut tc: Rc<TyCtx>,
+    ) -> Result<(Rc<Ctx>, Rc<TyCtx>), Error> {
         for (l, ty) in self.0.iter().enumerate() {
-            ty.univ_lvl(&c, &tc)?;
+            ty.univ_lvl(e, &c, &tc)?;
             let ty = ty.eval(&c)?;
             c = Rc::new(Ctx::Cons(Val::Var(Lvl(l)), c));
             tc = Rc::new(TyCtx::Cons(ty, tc));
@@ -21,6 +26,7 @@ impl Telescope {
     /// Validates that the telescope has universe level at most `max_univ_lvl`.
     fn validate_univ_level(
         &self,
+        e: &GlobalEnv,
         c: &Rc<Ctx>,
         tc: &Rc<TyCtx>,
         max_univ_lvl: &univ_lvl::Expr,
@@ -28,7 +34,7 @@ impl Telescope {
         let mut c = c.clone();
         let mut tc = tc.clone();
         for (l, ty) in self.0.iter().enumerate() {
-            if ty.univ_lvl(&c, &tc)? > *max_univ_lvl {
+            if ty.univ_lvl(e, &c, &tc)? > *max_univ_lvl {
                 return Err(Error::TyMismatch);
             }
             let ty = ty.eval(&c)?;
@@ -60,6 +66,7 @@ impl Telescope {
     /// Validates a currified application of the telescope to the arguments.
     fn validate_apply(
         &self,
+        e: &GlobalEnv,
         c: &Rc<Ctx>,
         args: &[Tm],
         args_c: &Rc<Ctx>,
@@ -74,7 +81,7 @@ impl Telescope {
         let mut i = 0;
         while let Val::Pi(closure) = pi {
             let arg = &args[i];
-            let ty = arg.ty_internal(args_c, args_tc)?;
+            let ty = arg.ty_internal(e, args_c, args_tc)?;
             if !ty.beta_eq(l, &closure.ty, l)? {
                 return Err(Error::TyMismatch);
             }
@@ -110,12 +117,12 @@ pub struct InductiveTypeFamily {
 
 impl InductiveTypeFamily {
     /// Validates the inductive type family.
-    fn validate(&self) -> Result<(), Error> {
-        let (inductive_c, inductive_tc) = self
-            .params
-            .add_to_ctx(Rc::new(Ctx::Nil), Rc::new(TyCtx::Nil))?;
+    fn validate(&self, e: &GlobalEnv) -> Result<(), Error> {
+        let (inductive_c, inductive_tc) =
+            self.params
+                .add_to_ctx(e, Rc::new(Ctx::Nil), Rc::new(TyCtx::Nil))?;
         self.indices
-            .validate_univ_level(&inductive_c, &inductive_tc, &self.univ_lvl)?;
+            .validate_univ_level(e, &inductive_c, &inductive_tc, &self.univ_lvl)?;
         for ctor in &self.ctors {
             if ctor.indices.len() != self.indices.0.len() {
                 return Err(Error::TyMismatch);
@@ -124,10 +131,10 @@ impl InductiveTypeFamily {
             let tc = inductive_tc.clone();
             for param in &ctor.params {
                 c.push(Val::Var(Lvl(c.len())));
-                tc.push(param.validate(&c, &tc, &self.indices, &inductive_c, &self.univ_lvl)?);
+                tc.push(param.validate(e, &c, &tc, &self.indices, &inductive_c, &self.univ_lvl)?);
             }
             self.indices
-                .validate_apply(&inductive_c, &ctor.indices, &c, &tc)?;
+                .validate_apply(e, &inductive_c, &ctor.indices, &c, &tc)?;
         }
         Ok(())
     }
@@ -160,6 +167,7 @@ impl CtorParam {
     /// Validates the constructor parameter type and returns a value that represents it.
     fn validate(
         &self,
+        e: &GlobalEnv,
         c: &Rc<Ctx>,
         tc: &Rc<TyCtx>,
         inductive_indices: &Telescope,
@@ -171,13 +179,13 @@ impl CtorParam {
                 if indices.len() != inductive_indices.0.len() {
                     return Err(Error::TyMismatch);
                 }
-                let (c, tc) = self.tele.add_to_ctx(c.clone(), tc.clone())?;
-                inductive_indices.validate_apply(inductive_c, &indices, &c, &tc)?;
+                let (c, tc) = self.tele.add_to_ctx(e, c.clone(), tc.clone())?;
+                inductive_indices.validate_apply(e, inductive_c, &indices, &c, &tc)?;
                 todo!()
             }
             CtorParamLast::Other(ty) => {
-                let (c, tc) = self.tele.add_to_ctx(c.clone(), tc.clone())?;
-                if ty.univ_lvl(&c, &tc)? > *max_univ_lvl {
+                let (c, tc) = self.tele.add_to_ctx(e, c.clone(), tc.clone())?;
+                if ty.univ_lvl(e, &c, &tc)? > *max_univ_lvl {
                     return Err(Error::TyMismatch);
                 }
                 ty.eval(&c)?

--- a/crates/endive-kernel/src/induction.rs
+++ b/crates/endive-kernel/src/induction.rs
@@ -1,0 +1,63 @@
+use crate::{univ_lvl, Tm};
+
+/// A sequence of types. For each type, an argument of that type is bound in every subsequent type.
+pub struct Telescope(pub Vec<Tm>);
+
+/// A parameterized family of inductive types.
+pub struct InductiveTypeFamily {
+    /// The parameters of the family.
+    ///
+    /// They are bound in the indices and constructors, and constructors have to use them everytime
+    /// they refer to the family.
+    pub params: Telescope,
+
+    /// The indices of the family.
+    ///
+    /// They are not bound in the constructors.
+    pub indices: Telescope,
+
+    /// The universe level to which the inducive types belong.
+    pub univ_lvl: univ_lvl::Expr,
+
+    /// The number of universe variables that are used in the family.
+    pub univ_vars: usize,
+
+    /// The constructors of the family.
+    pub ctors: Vec<Ctor>,
+}
+
+/// A constructor of an inductive type family.
+pub struct Ctor {
+    /// The parameters of the constructor.
+    pub params: Vec<CtorParam>,
+
+    /// The indices for the constructed value.
+    ///
+    /// For example, if the inductive type family is `F` with parameters `p : A, q : B` and indices
+    /// `i : I, j : J`, then constructor `C : (p : A) -> (q : B) -> (i : I) -> C i t`, then
+    /// `indices` contains the terms `i` and `t`.
+    pub indices: Vec<Tm>,
+}
+
+/// A constructor parameter, which is a chain of zero or more dependent type products with
+/// additional constraints to ensure strict positivity.
+pub struct CtorParam {
+    /// The telescope of the parameter.
+    pub tele: Telescope,
+
+    /// The last type in the chain of dependent product types.
+    pub tail: CtorParamTail,
+}
+
+/// The last type in the chain of dependent product types representing a constructor parameter.
+///
+/// See [`CtorParam`].
+pub enum CtorParamTail {
+    /// The inductive type family being defined, applied to the bound parameters and given indices,
+    /// which must have the same length as the indices of the family (i.e the inductive type family
+    /// must be fully applied).
+    This { indices: Vec<Tm> },
+
+    /// Another type, which does not contain the inductive type family being defined.
+    Other(Tm),
+}

--- a/crates/endive-kernel/src/lib.rs
+++ b/crates/endive-kernel/src/lib.rs
@@ -220,7 +220,7 @@ impl Tm {
     /// Unlike [`ty`] which is the public interface, this method takes a local context and a typing
     /// local context as arguments and returns a value corresponding to the inferred type. This is
     /// useful for inferring the type of a subterm in a larger term.
-    fn ty_internal(&self, c: &Rc<Ctx>, tc: &Rc<TyCtx>) -> Result<Val, Error> {
+    pub(crate) fn ty_internal(&self, c: &Rc<Ctx>, tc: &Rc<TyCtx>) -> Result<Val, Error> {
         let l = Lvl(c.len());
 
         match self {

--- a/crates/endive-kernel/src/lib.rs
+++ b/crates/endive-kernel/src/lib.rs
@@ -6,6 +6,7 @@
 //! and therefore more amenable to formal reasoning. This separation follows what is known as the
 //! de Bruijn criterion.
 
+mod induction;
 pub mod univ_lvl;
 
 use std::{ops::Neg, rc::Rc};

--- a/crates/endive-kernel/src/lib.rs
+++ b/crates/endive-kernel/src/lib.rs
@@ -6,10 +6,12 @@
 //! and therefore more amenable to formal reasoning. This separation follows what is known as the
 //! de Bruijn criterion.
 
+mod closure;
 mod global_env;
 mod induction;
 pub mod univ_lvl;
 
+use closure::Closure;
 pub use global_env::*;
 pub use induction::*;
 
@@ -538,30 +540,6 @@ impl Tm {
                 val: Box::new(val.unlift(k, by)?),
             }),
         }
-    }
-}
-
-/// Lambda abstraction or dependent product type with a local context.
-#[derive(Clone, Debug)]
-struct Closure {
-    pub ty: Val,
-    pub body: Tm,
-    pub c: Rc<Ctx>,
-}
-
-impl Closure {
-    /// Applies the closure to a value.
-    fn apply(&self, val: Val) -> Result<Val, Error> {
-        self.body.eval(&self.c.push(val))
-    }
-
-    /// Reifies the closure into an abstraction in normal form. Variables are reified into de
-    /// Bruijn indices assuming current level `l`.
-    fn reify(&self, l: Lvl) -> Result<Binding, Error> {
-        Ok(Binding {
-            bound_ty: self.ty.reify(l)?,
-            body: self.apply(Val::Var(l))?.reify(Lvl(l.0 + 1))?,
-        })
     }
 }
 

--- a/crates/endive-kernel/src/lib.rs
+++ b/crates/endive-kernel/src/lib.rs
@@ -6,8 +6,12 @@
 //! and therefore more amenable to formal reasoning. This separation follows what is known as the
 //! de Bruijn criterion.
 
+mod global_env;
 mod induction;
 pub mod univ_lvl;
+
+pub use global_env::*;
+pub use induction::*;
 
 use std::{ops::Neg, rc::Rc};
 

--- a/crates/endive-parse/src/lib.rs
+++ b/crates/endive-parse/src/lib.rs
@@ -1,12 +1,12 @@
 //! Parsing for lambda terms.
 
-use endive_lambda::{Binding, Tm};
 use chumsky::{
     primitive::just,
     recursive::recursive,
     text::{ident, whitespace},
     Parser,
 };
+use endive_lambda::{Binding, Tm};
 
 pub fn parser<'src>() -> impl Parser<'src, &'src str, Tm> {
     recursive(|tm| {

--- a/crates/endive-wasm/src/lib.rs
+++ b/crates/endive-wasm/src/lib.rs
@@ -32,7 +32,12 @@ fn js_univ_lvl_to_kernel_univ_lvl(value: &JsValue) -> Result<univ_lvl::Expr, JsV
 fn kernel_univ_lvl_to_js_univ_lvl(expr: &univ_lvl::Expr) -> JsValue {
     let obj = Object::new();
     for (var, c) in expr.iter() {
-        Reflect::set(&obj, &JsValue::from_f64(var.0 as f64), &JsValue::from_f64(c as f64)).unwrap();
+        Reflect::set(
+            &obj,
+            &JsValue::from_f64(var.0 as f64),
+            &JsValue::from_f64(c as f64),
+        )
+        .unwrap();
     }
     obj.into()
 }
@@ -47,9 +52,10 @@ fn js_tm_to_kernel_tm(value: &JsValue) -> Result<Tm, JsValue> {
                 .as_f64()
                 .ok_or_else(|| TypeError::new("Variable index must be a number"))?;
             Ok(Tm::Var(Ix(ix as usize)))
-        },
+        }
         "abstraction" => {
-            let bound_ty = js_tm_to_kernel_tm(&Reflect::get(value, &JsValue::from_str("variable"))?)?;
+            let bound_ty =
+                js_tm_to_kernel_tm(&Reflect::get(value, &JsValue::from_str("variable"))?)?;
             let body = js_tm_to_kernel_tm(&Reflect::get(value, &JsValue::from_str("body"))?)?;
             Ok(Tm::Abs(Box::new(Binding { bound_ty, body })))
         }
@@ -57,16 +63,20 @@ fn js_tm_to_kernel_tm(value: &JsValue) -> Result<Tm, JsValue> {
             let n = js_tm_to_kernel_tm(&Reflect::get(&value, &JsValue::from_str("f"))?)?;
             let m = js_tm_to_kernel_tm(&Reflect::get(&value, &JsValue::from_str("argument"))?)?;
             Ok(Tm::App(Box::new(n), Box::new(m)))
-        },
+        }
         "pi" => {
-            let bound_ty = js_tm_to_kernel_tm(&Reflect::get(&value, &JsValue::from_str("variable"))?)?;
+            let bound_ty =
+                js_tm_to_kernel_tm(&Reflect::get(&value, &JsValue::from_str("variable"))?)?;
             let body = js_tm_to_kernel_tm(&Reflect::get(&value, &JsValue::from_str("body"))?)?;
             Ok(Tm::Pi(Box::new(Binding { bound_ty, body })))
-        },
+        }
         "universe" => {
-            let level = js_univ_lvl_to_kernel_univ_lvl(&Reflect::get(&value, &JsValue::from_str("level"))?)?;
+            let level = js_univ_lvl_to_kernel_univ_lvl(&Reflect::get(
+                &value,
+                &JsValue::from_str("level"),
+            )?)?;
             Ok(Tm::U(level))
-        },
+        }
         "fixpoint" => {
             let ty = js_tm_to_kernel_tm(&Reflect::get(&value, &JsValue::from_str("target"))?)?;
             let ctors = Reflect::get(&value, &JsValue::from_str("constructors"))?
@@ -79,12 +89,13 @@ fn js_tm_to_kernel_tm(value: &JsValue) -> Result<Tm, JsValue> {
                 ty: Box::new(ty),
                 ctors,
             })
-        },
+        }
         "constructor" => {
             let fix = js_tm_to_kernel_tm(&Reflect::get(&value, &JsValue::from_str("fixpoint"))?)?;
             let i = Reflect::get(&value, &JsValue::from_str("index"))?
                 .as_f64()
-                .ok_or_else(|| TypeError::new("Constructor index must be a number"))? as usize;
+                .ok_or_else(|| TypeError::new("Constructor index must be a number"))?
+                as usize;
             let args = Reflect::get(&value, &JsValue::from_str("arguments"))?
                 .dyn_ref::<Array>()
                 .ok_or_else(|| TypeError::new("Constructor arguments must be an array"))?
@@ -96,7 +107,7 @@ fn js_tm_to_kernel_tm(value: &JsValue) -> Result<Tm, JsValue> {
                 i,
                 args,
             })
-        },
+        }
         "induction" => {
             let val = js_tm_to_kernel_tm(&Reflect::get(&value, &JsValue::from_str("value"))?)?;
             let motive = js_tm_to_kernel_tm(&Reflect::get(&value, &JsValue::from_str("motive"))?)?;
@@ -111,7 +122,7 @@ fn js_tm_to_kernel_tm(value: &JsValue) -> Result<Tm, JsValue> {
                 motive: Box::new(motive),
                 cases,
             })
-        },
+        }
         _ => Err(TypeError::new("Unknown term type").into()),
     }
 }
@@ -120,40 +131,95 @@ fn kernel_tm_to_js_tm(tm: &Tm) -> JsValue {
     match tm {
         Tm::Var(Ix(ix)) => {
             let obj = Object::new();
-            Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("variable")).unwrap();
-            Reflect::set(&obj, &JsValue::from_str("index"), &JsValue::from_f64(*ix as f64)).unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("type"),
+                &JsValue::from_str("variable"),
+            )
+            .unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("index"),
+                &JsValue::from_f64(*ix as f64),
+            )
+            .unwrap();
             obj.into()
-        },
+        }
         Tm::Abs(binding) => {
             let obj = Object::new();
-            Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("abstraction")).unwrap();
-            Reflect::set(&obj, &JsValue::from_str("variable"), &kernel_tm_to_js_tm(&binding.bound_ty)).unwrap();
-            Reflect::set(&obj, &JsValue::from_str("body"), &kernel_tm_to_js_tm(&binding.body)).unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("type"),
+                &JsValue::from_str("abstraction"),
+            )
+            .unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("variable"),
+                &kernel_tm_to_js_tm(&binding.bound_ty),
+            )
+            .unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("body"),
+                &kernel_tm_to_js_tm(&binding.body),
+            )
+            .unwrap();
             obj.into()
-        },
+        }
         Tm::App(n, m) => {
             let obj = Object::new();
-            Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("application")).unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("type"),
+                &JsValue::from_str("application"),
+            )
+            .unwrap();
             Reflect::set(&obj, &JsValue::from_str("f"), &kernel_tm_to_js_tm(n)).unwrap();
             Reflect::set(&obj, &JsValue::from_str("argument"), &kernel_tm_to_js_tm(m)).unwrap();
             obj.into()
-        },
+        }
         Tm::Pi(binding) => {
             let obj = Object::new();
             Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("pi")).unwrap();
-            Reflect::set(&obj, &JsValue::from_str("variable"), &kernel_tm_to_js_tm(&binding.bound_ty)).unwrap();
-            Reflect::set(&obj, &JsValue::from_str("body"), &kernel_tm_to_js_tm(&binding.body)).unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("variable"),
+                &kernel_tm_to_js_tm(&binding.bound_ty),
+            )
+            .unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("body"),
+                &kernel_tm_to_js_tm(&binding.body),
+            )
+            .unwrap();
             obj.into()
-        },
+        }
         Tm::U(level) => {
             let obj = Object::new();
-            Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("universe")).unwrap();
-            Reflect::set(&obj, &JsValue::from_str("level"), &kernel_univ_lvl_to_js_univ_lvl(level)).unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("type"),
+                &JsValue::from_str("universe"),
+            )
+            .unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("level"),
+                &kernel_univ_lvl_to_js_univ_lvl(level),
+            )
+            .unwrap();
             obj.into()
-        },
+        }
         Tm::Fix { ty, ctors } => {
             let obj = Object::new();
-            Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("fixpoint")).unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("type"),
+                &JsValue::from_str("fixpoint"),
+            )
+            .unwrap();
             Reflect::set(&obj, &JsValue::from_str("target"), &kernel_tm_to_js_tm(ty)).unwrap();
             let ctors = ctors
                 .iter()
@@ -161,31 +227,56 @@ fn kernel_tm_to_js_tm(tm: &Tm) -> JsValue {
                 .collect::<Array>();
             Reflect::set(&obj, &JsValue::from_str("constructors"), &ctors).unwrap();
             obj.into()
-        },
+        }
         Tm::Ctor { fix, i, args } => {
             let obj = Object::new();
-            Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("constructor")).unwrap();
-            Reflect::set(&obj, &JsValue::from_str("fixpoint"), &kernel_tm_to_js_tm(fix)).unwrap();
-            Reflect::set(&obj, &JsValue::from_str("index"), &JsValue::from_f64(*i as f64)).unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("type"),
+                &JsValue::from_str("constructor"),
+            )
+            .unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("fixpoint"),
+                &kernel_tm_to_js_tm(fix),
+            )
+            .unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("index"),
+                &JsValue::from_f64(*i as f64),
+            )
+            .unwrap();
             let args = args
                 .iter()
                 .map(|arg| kernel_tm_to_js_tm(arg))
                 .collect::<Array>();
             Reflect::set(&obj, &JsValue::from_str("arguments"), &args).unwrap();
             obj.into()
-        },
+        }
         Tm::Ind { val, motive, cases } => {
             let obj = Object::new();
-            Reflect::set(&obj, &JsValue::from_str("type"), &JsValue::from_str("induction")).unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("type"),
+                &JsValue::from_str("induction"),
+            )
+            .unwrap();
             Reflect::set(&obj, &JsValue::from_str("value"), &kernel_tm_to_js_tm(val)).unwrap();
-            Reflect::set(&obj, &JsValue::from_str("motive"), &kernel_tm_to_js_tm(motive)).unwrap();
+            Reflect::set(
+                &obj,
+                &JsValue::from_str("motive"),
+                &kernel_tm_to_js_tm(motive),
+            )
+            .unwrap();
             let cases = cases
                 .iter()
                 .map(|case| kernel_tm_to_js_tm(case))
                 .collect::<Array>();
             Reflect::set(&obj, &JsValue::from_str("cases"), &cases).unwrap();
             obj.into()
-        },
+        }
     }
 }
 
@@ -198,12 +289,20 @@ fn kernel_error_to_js_error(err: endive_kernel::Error) -> JsValue {
 
 #[wasm_bindgen]
 pub fn normalize(n: &JsValue) -> Result<JsValue, JsValue> {
-    Ok(kernel_tm_to_js_tm(&js_tm_to_kernel_tm(&n)?.normalize().map_err(kernel_error_to_js_error)?))
+    Ok(kernel_tm_to_js_tm(
+        &js_tm_to_kernel_tm(&n)?
+            .normalize()
+            .map_err(kernel_error_to_js_error)?,
+    ))
 }
 
 #[wasm_bindgen(js_name = "inferType")]
 pub fn ty(n: &JsValue) -> Result<JsValue, JsValue> {
-    Ok(kernel_tm_to_js_tm(&js_tm_to_kernel_tm(&n)?.ty().map_err(kernel_error_to_js_error)?))
+    Ok(kernel_tm_to_js_tm(
+        &js_tm_to_kernel_tm(&n)?
+            .ty()
+            .map_err(kernel_error_to_js_error)?,
+    ))
 }
 
 #[wasm_bindgen(js_name = "betaEquivalent")]

--- a/crates/endive-wasm/src/lib.rs
+++ b/crates/endive-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 //! WebAssembly interface to Endive.
 
-use endive_kernel::{univ_lvl, Binding, Ix, Tm};
+use endive_kernel::{univ_lvl, Binding, GlobalEnv, Ix, Tm};
 use js_sys::{Array, Error, Object, Reflect, TypeError};
 use wasm_bindgen::prelude::*;
 
@@ -300,7 +300,7 @@ pub fn normalize(n: &JsValue) -> Result<JsValue, JsValue> {
 pub fn ty(n: &JsValue) -> Result<JsValue, JsValue> {
     Ok(kernel_tm_to_js_tm(
         &js_tm_to_kernel_tm(&n)?
-            .ty()
+            .ty(&GlobalEnv::new())
             .map_err(kernel_error_to_js_error)?,
     ))
 }


### PR DESCRIPTION
Move inductive types to a global context instead of having them duplicated in the terms. This will make the kernel code easier to understand, which will help me. It will also make the kernel match more closely the Calculus of Inductive Constructions and improve performance (not important, but a nice side effect). Finally, I think it will make the WASM interface easier to use. 

(Currently working on this, not done at all!)